### PR TITLE
ng-planetaryjs looks for global with AMD loader

### DIFF
--- a/dist/planetaryjs.js
+++ b/dist/planetaryjs.js
@@ -1,4 +1,4 @@
-/*! Planetary.js v1.1.0
+/*! Planetary.js v1.1.1
  *  Copyright (c) 2013 Brandon Tilley
  *
  *  Released under the MIT license


### PR DESCRIPTION
While using RequireJS to AMD load ng-planetaryjs, planetaryjs, and their dependencies, ng-planetaryjs still looks for global object planetaryjs (such as in `var globe = planetaryjs.planet();`). Thus use the UMD pattern "AMD with global, Node, or global" instead of "AMD, Node, or browser global" from https://sublime.wbond.net/packages/UMD%20snippets .
