### PR TITLE
Preparing module for npm publishing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/planetaryjs');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "planetary.js",
   "version": "1.1.1",
   "description": "Awesome interactive globes for the web",
-  "main": "index.js",
+  "main": "dist/planetaryjs",
   "scripts": {
     "build": "rm -r dist/ ; gulp && cp dist/planetaryjs.min.js site/public/js/lib",
     "jshint": "gulp jshint",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "planetary.js",
   "version": "1.1.1",
   "description": "Awesome interactive globes for the web",
-  "main": "dist/planetaryjs",
+  "main": "index.js",
   "scripts": {
     "build": "rm -r dist/ ; gulp && cp dist/planetaryjs.min.js site/public/js/lib",
     "jshint": "gulp jshint",


### PR DESCRIPTION
Hi Brandon -- I'm wanting to use npm to manage my planetaryjs dependencies. I've tested this PR locally and it work well like the following:

```
var Planetaryjs = require('planetary.js'); // this could just as easily be `var planetaryjs = require('planetary.js');` and then have the case match the existing docs.
var planet = Planetaryjs.planet()
planet.loadPlugin(Planetaryjs.plugins.drag());  
planet.projection.scale(75).translate([75, 75]);
var canvas = document.getElementById('globe');
planet.draw(canvas);
```

Though I wasn't sure why you had the `main` set to `dist/planetary.js` in `package.json` (I understand why it is so in `bower.json`).

==
Added index.js with module.export.
Updated the mainfile in package.json to point and the index.js file.