### PR TITLE
Fixes incorrect dependency notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-replace": "~0.3.0"
   },
   "dependencies": {
-    "topojson": ">=1.4.6",
-    "d3": ">=3.3.13"
+    "topojson": "^1.4.6",
+    "d3": "^3.3.13"
   }
 }


### PR DESCRIPTION
Locks dependencies down to:
  - topojson version 1
  - d3 version 3

As described in the docs.